### PR TITLE
fix(prefer-import): provide replacement data for better error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ Add `collation` to the plugins and rules section of your `.eslintrc` configurati
 
 ## Rules
 
-| Rule                                                                                                              | Description                                       | Fixable  |
-| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------- |
-| [collation/group-exports](https://eslint-plugin-collation.brandonscott.me/docs/rules/group-exports)               | Consolidates multiple export statements           | :wrench: |
-| [collation/no-default-export](https://eslint-plugin-collation.brandonscott.me/docs/rules/no-inline-export)        | Enforces exports to be named                      | :wrench: |
-| [collation/no-inline-export](https://eslint-plugin-collation.brandonscott.me/docs/rules/no-inline-export)         | Enforces exports to appear at the end of the file | :wrench: |
-| [collation/sort-dependency-list](https://eslint-plugin-collation.brandonscott.me/docs/rules/sort-dependency-list) | Sorts React dependency lists                      | :wrench: |
-| [collation/sort-exports](https://eslint-plugin-collation.brandonscott.me/docs/rules/sort-exports)                 | Sorts specifiers in an export statement           | :wrench: |
+| Rule                                                                                                              | Description                                                                                                | Fixable  |
+| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------- |
+| [collation/group-exports](https://eslint-plugin-collation.brandonscott.me/docs/rules/group-exports)               | Consolidates multiple export statements                                                                    | :wrench: |
+| [collation/no-default-export](https://eslint-plugin-collation.brandonscott.me/docs/rules/no-inline-export)        | Enforces exports to be named                                                                               | :wrench: |
+| [collation/no-inline-export](https://eslint-plugin-collation.brandonscott.me/docs/rules/no-inline-export)         | Enforces exports to appear at the end of the file                                                          | :wrench: |
+| [collation/prefer-import](https://eslint-plugin-collation.brandonscott.me/docs/rules/prefer-import)               | Enforces imports from a preferred module, i.e. for wrapped library functionality or ESM-friendly packages. | :wrench: |
+| [collation/sort-dependency-list](https://eslint-plugin-collation.brandonscott.me/docs/rules/sort-dependency-list) | Sorts React dependency lists                                                                               | :wrench: |
+| [collation/sort-exports](https://eslint-plugin-collation.brandonscott.me/docs/rules/sort-exports)                 | Sorts specifiers in an export statement                                                                    | :wrench: |
 
 For documentation and examples for the available rules, see [Rules](https://eslint-plugin-collation.brandonscott.me/docs/rules/)

--- a/documentation/docs/rules/prefer-import.md
+++ b/documentation/docs/rules/prefer-import.md
@@ -27,6 +27,8 @@ Given the following ESLint config:
 }
 ```
 
+This import:
+
 ```ts
 import { isEmpty, isNil } from "lodash";
 ```
@@ -87,11 +89,13 @@ The fix for this rule does not handle any whitespace/formatting, and may add add
 
 It shouldn't produce _broken_ code though, so if something isn't being parsed correctly, please [open up an issue](https://github.com/brandongregoryscott/eslint-plugin-collation/issues/new/choose)!
 
+Additionally, this plugin does not perform any module resolution - it's a pretty simple string replacement utility, so if your auto-fixed import isn't correct, you may need to tweak your config.
+
 ### Twilio Paste
 
 In addition to reducing bundle size when using `lodash` functions, one of the main motivators around creating this rule was the [guidance by the Twilio Paste team on best practices](https://paste.twilio.design/core) for importing from `@twilio-paste/core`. While the [`no-restricted-imports`](https://eslint.org/docs/latest/rules/no-restricted-imports) can be configured to nudge people against using `@twilio-paste/core`, it still requires you to update the import manually, and at the time of writing, VS Code doesn't know how to suggest imports from the individual packages in `@twilio-paste/core`, such as `@twilio-paste/core/box`.
 
-As such, I've written an extensive (but likely non-exhaustive) configuration list oriented around improving the DX while using [Twilio Paste](https://paste.twilio.design/). It isn't bundled or exported, but should serve as a good baseline config for consuming applications.
+As such, I've written an extensive (but likely non-exhaustive) configuration list oriented around improving the DX while using [Twilio Paste](https://paste.twilio.design/). It isn't bundled or exported, but should serve as a good baseline config for consuming applications. You can also view the tests that run against this config to verify expected output [here](https://github.com/brandongregoryscott/eslint-plugin-collation/blob/3f6721ebf16f688cfcf289d75936e9eff525ccec/src/rules/prefer-import.test.ts#L291-L1306).
 
 <details>
 <summary>Click to view Twilio Paste config</summary>

--- a/src/rules/prefer-import.test.ts
+++ b/src/rules/prefer-import.test.ts
@@ -94,6 +94,10 @@ ruleTester.run("prefer-import", preferImport, {
             errors: [
                 {
                     messageId: "preferImport",
+                    data: {
+                        importName: "Box",
+                        replacementModuleSpecifier: "@twilio-paste/core/box",
+                    },
                 },
             ],
         },
@@ -114,7 +118,11 @@ import { Heading } from '@twilio-paste/core/heading';
 import { Paragraph } from '@twilio-paste/core/paragraph';`,
             errors: [
                 {
-                    messageId: "preferImport",
+                    messageId: "preferImportMultiple",
+                    data: {
+                        message:
+                            "Import 'Box' from '@twilio-paste/core/box', 'Heading' from '@twilio-paste/core/heading', and 'Paragraph' from '@twilio-paste/core/paragraph'.",
+                    },
                 },
             ],
         },
@@ -205,7 +213,15 @@ import { Paragraph } from '@twilio-paste/core/paragraph';`,
             code: "import { isEmpty, isNil } from 'lodash'",
             output: `import isEmpty from 'lodash/isEmpty';
 import isNil from 'lodash/isNil';`,
-            errors: [{ messageId: "preferImport" }],
+            errors: [
+                {
+                    messageId: "preferImportMultiple",
+                    data: {
+                        message:
+                            "Import 'isEmpty' from 'lodash/isEmpty', and 'isNil' from 'lodash/isNil'.",
+                    },
+                },
+            ],
         },
         {
             name: "should not produce fix overlaps with large import",
@@ -271,7 +287,15 @@ import useInfiniteScroll from 'hooks/use-infinite-scroll'
 import useRouter from 'hooks/use-router'
 import useSpace from 'hooks/use-space'
 import useWorkspace from 'hooks/use-workspace'`,
-            errors: [{ messageId: "preferImport" }],
+            errors: [
+                {
+                    messageId: "preferImportMultiple",
+                    data: {
+                        message:
+                            "Import 'TBody, THead, Table, Td, Th, Tr' from '@twilio-paste/core/table', 'Button' from '@twilio-paste/core/button', 'Text' from '@twilio-paste/core/text', and 'Truncate' from '@twilio-paste/core/truncate'.",
+                    },
+                },
+            ],
         },
         {
             options: [


### PR DESCRIPTION
Fixes the error message that was expecting substitution data for `importName` and `replacementModuleSpecifier`, and handles more complex cases where one import may be split into multiple imports based on the parsed configuration. I updated the basic test cases to verify both scenarios.