### PR TITLE
fix(prefer-import): use local isIdentifier type guard instead of reaching into dist/ast-utils

### DIFF
--- a/src/rules/prefer-import.ts
+++ b/src/rules/prefer-import.ts
@@ -27,6 +27,7 @@ import {
     getImportSpecifierText,
     getModuleSpecifier,
     getName,
+    isIdentifier,
     isImportSpecifier,
     toDefaultImportDeclaration,
     toImportDeclaration,
@@ -40,7 +41,6 @@ import {
     removeImportClause,
 } from "../utils/fixer-utils";
 import { getValues, iterate, updateIn } from "../utils/map-utils";
-import { isIdentifier } from "@typescript-eslint/utils/dist/ast-utils";
 
 interface PreferImportOptions {
     [moduleSpecifier: string]: ImportRule | ImportRule[];

--- a/src/utils/node-utils.ts
+++ b/src/utils/node-utils.ts
@@ -105,12 +105,16 @@ const toImportDeclaration = (
 ): string =>
     `import { ${arrify(specifiers).join(", ")} } from '${moduleSpecifier}';`;
 
+const isIdentifier = (node: TSESTree.Node): node is TSESTree.Identifier =>
+    node.type === AST_NODE_TYPES.Identifier;
+
 export {
     getImportSpecifierText,
     getModuleSpecifier,
     getName,
     isCommaToken,
     isDeclaration,
+    isIdentifier,
     isIdentifierToken,
     isImportDeclaration,
     isImportSpecifier,


### PR DESCRIPTION
This was causing a runtime error since `@typescript-eslint/utils/dist/ast-utils` is not bundled.